### PR TITLE
(PUP-4567) Update acceptance infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ spec/fixtures
 .vagrant
 .bundle
 vendor
+log
+tmp

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -3,22 +3,97 @@ require 'spec_helper_acceptance'
 describe 'agent_upgrade class' do
 
   context 'default parameters' do
-    # Using puppet_apply as a helper
+    before(:all) { setup_puppet }
+    after (:all) { teardown_puppet }
+
     it 'should work idempotently with no errors' do
       pp = <<-EOS
       class { 'agent_upgrade': }
       EOS
 
-      # Run it twice and test for idempotency
+      # TODO: Run it twice and test for idempotency; requires ability to change
+      #       Beaker config to AIO mid-run.
       apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes  => true)
+      #apply_manifest(pp, :catch_changes  => true)
     end
 
-    describe package('agent_upgrade') do
+    describe package('puppet-agent') do
       it { is_expected.to be_installed }
     end
 
-    describe service('agent_upgrade') do
+    describe service('puppet') do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+
+    describe service('mcollective') do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+  end
+
+  context 'no services enabled on install' do
+    before(:all) { setup_puppet }
+    after (:all) { teardown_puppet }
+
+    it 'should work idempotently with no errors' do
+      pp = <<-EOS
+      class { 'agent_upgrade': service_names => [] }
+      EOS
+
+      # TODO: Run it twice and test for idempotency; requires ability to change
+      #       Beaker config to AIO mid-run.
+      apply_manifest(pp, :catch_failures => true)
+      #apply_manifest(pp, :catch_changes  => true)
+    end
+
+    describe package('puppet-agent') do
+      it { is_expected.to be_installed }
+    end
+
+    describe service('puppet') do
+      it { is_expected.to_not be_enabled }
+      it { is_expected.to_not be_running }
+    end
+
+    describe service('mcollective') do
+      it { is_expected.to_not be_enabled }
+      it { is_expected.to_not be_running }
+    end
+  end
+
+  context 'with mcollective configured' do
+    before(:all) { setup_puppet }
+    after (:all) { teardown_puppet }
+
+    it 'should work idempotently with no errors' do
+      pp = <<-EOS
+      file { '/etc/mcollective': ensure => directory }
+      file { '/etc/mcollective/server.cfg':
+        ensure  => file,
+        notify  => Class['agent_upgrade'],
+        content => '#{File.read(File.join(File.expand_path(File.dirname(__FILE__)), 'server.cfg'))}'
+      }
+
+      class { 'agent_upgrade': }
+      EOS
+
+      # TODO: Run it twice and test for idempotency; requires ability to change
+      #       Beaker config to AIO mid-run.
+      apply_manifest(pp, :catch_failures => true)
+      #apply_manifest(pp, :catch_changes  => true)
+    end
+
+    describe package('puppet-agent') do
+      it { is_expected.to be_installed }
+    end
+
+    describe service('puppet') do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+
+    describe service('mcollective') do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
     end

--- a/spec/acceptance/nodesets/centos-511-x64.yml
+++ b/spec/acceptance/nodesets/centos-511-x64.yml
@@ -1,7 +1,7 @@
 HOSTS:
   centos-511-x64:
     roles:
-      - master
+      - agent
     platform: el-5-x86_64
     box: puppetlabs/centos-5.11-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-5.11-64-nocm
@@ -10,3 +10,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
+  masterless: true

--- a/spec/acceptance/nodesets/centos-66-x64.yml
+++ b/spec/acceptance/nodesets/centos-66-x64.yml
@@ -1,7 +1,7 @@
 HOSTS:
   centos-66-x64:
     roles:
-      - master
+      - agent
     platform: el-6-x86_64
     box: puppetlabs/centos-6.6-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
@@ -10,3 +10,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
+  masterless: true

--- a/spec/acceptance/nodesets/centos-66-x64.yml
+++ b/spec/acceptance/nodesets/centos-66-x64.yml
@@ -6,6 +6,7 @@ HOSTS:
     box: puppetlabs/centos-6.6-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
     hypervisor: vagrant
+
 CONFIG:
   log_level: verbose
   type: foss

--- a/spec/acceptance/nodesets/centos-7-x64.yml
+++ b/spec/acceptance/nodesets/centos-7-x64.yml
@@ -3,8 +3,8 @@ HOSTS:
     roles:
       - master
     platform: el-7-x86_64
-    box: chef/centos-7.0
-    box_url: https://vagrantcloud.com/chef/boxes/centos-7.0
+    box: puppetlabs/centos-7.0-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
     hypervisor: vagrant
 
 CONFIG:

--- a/spec/acceptance/nodesets/centos-7-x64.yml
+++ b/spec/acceptance/nodesets/centos-7-x64.yml
@@ -1,7 +1,7 @@
 HOSTS:
   centos-7-x64:
     roles:
-      - master
+      - agent
     platform: el-7-x86_64
     box: puppetlabs/centos-7.0-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
@@ -10,3 +10,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
+  masterless: true

--- a/spec/acceptance/nodesets/debian-609-x64.yml
+++ b/spec/acceptance/nodesets/debian-609-x64.yml
@@ -1,7 +1,7 @@
 HOSTS:
   debian-609-x64:
     roles:
-      - master
+      - agent
     platform: debian-6-amd64
     box: puppetlabs/debian-6.0.9-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/debian-6.0.9-64-nocm
@@ -10,3 +10,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
+  masterless: true

--- a/spec/acceptance/nodesets/debian-76-x64.yml
+++ b/spec/acceptance/nodesets/debian-76-x64.yml
@@ -1,7 +1,7 @@
 HOSTS:
   debian-76-x64:
     roles:
-      - master
+      - agent
     platform: debian-7-amd64
     box: puppetlabs/debian-7.6-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/debian-7.6-64-nocm
@@ -10,3 +10,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
+  masterless: true

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,10 +1,10 @@
 HOSTS:
-  ubuntu-server-1204-x64:
+  centos-7-x64:
     roles:
       - master
-    platform: ubuntu-1204-amd64
-    box: puppetlabs/ubuntu-12.04-64-nocm
-    box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-12.04-64-nocm
+    platform: el-7-x86_64
+    box: puppetlabs/centos-7.0-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
     hypervisor: vagrant
 
 CONFIG:

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,7 +1,16 @@
 HOSTS:
-  centos-7-x64:
+  centos-7-x64-master:
     roles:
       - master
+    platform: el-7-x86_64
+    box: puppetlabs/centos-7.0-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+    hypervisor: vagrant
+
+  centos-7-x64-agent:
+    roles:
+      - agent
+      - default
     platform: el-7-x86_64
     box: puppetlabs/centos-7.0-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm

--- a/spec/acceptance/nodesets/fedora-20-x64.yml
+++ b/spec/acceptance/nodesets/fedora-20-x64.yml
@@ -1,7 +1,7 @@
 HOSTS:
   fedora-20-x64:
     roles:
-      - master
+      - agent
     platform: el-7-x86_64
     box: chef/fedora-20
     box_url: https://vagrantcloud.com/chef/boxes/fedora-20
@@ -10,3 +10,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
+  masterless: true

--- a/spec/acceptance/nodesets/ubuntu-1204-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-1204-x64.yml
@@ -1,7 +1,7 @@
 HOSTS:
-  ubuntu-server-1204-x64:
+  ubuntu-1204-x64:
     roles:
-      - master
+      - agent
     platform: ubuntu-1204-amd64
     box: puppetlabs/ubuntu-12.04-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-12.04-64-nocm
@@ -10,3 +10,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
+  masterless: true

--- a/spec/acceptance/nodesets/ubuntu-1404-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-1404-x64.yml
@@ -1,7 +1,7 @@
 HOSTS:
-  ubuntu-server-1404-x64:
+  ubuntu-1404-x64:
     roles:
-      - master
+      - agent
     platform: ubuntu-1404-amd64
     box: puppetlabs/ubuntu-14.04-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-nocm
@@ -10,3 +10,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
+  masterless: true

--- a/spec/acceptance/server.cfg
+++ b/spec/acceptance/server.cfg
@@ -1,0 +1,98 @@
+# Connector settings (required):
+# -----------------------------
+
+connector = activemq
+direct_addressing = 1
+
+# ActiveMQ connector settings:
+plugin.activemq.pool.size = 1
+plugin.activemq.pool.1.host = middleware.example.net
+plugin.activemq.pool.1.port = 61614
+plugin.activemq.pool.1.user = mcollective
+plugin.activemq.pool.1.password = secret
+plugin.activemq.pool.1.ssl = 1
+plugin.activemq.pool.1.ssl.ca = /var/lib/puppet/ssl/certs/ca.pem
+plugin.activemq.pool.1.ssl.cert = /var/lib/puppet/ssl/certs/web01.example.com.pem
+plugin.activemq.pool.1.ssl.key = /var/lib/puppet/ssl/private_keys/web01.example.com.pem
+plugin.activemq.pool.1.ssl.fallback = 0
+plugin.activemq.stomp_1_0_fallback = 0
+plugin.activemq.heartbeat_interval = 30
+plugin.activemq.max_hbread_fails = 2
+plugin.activemq.max_hbrlck_fails = 0
+
+# RabbitMQ connector settings:
+plugin.rabbitmq.vhost = /mcollective
+plugin.rabbitmq.pool.size = 1
+plugin.rabbitmq.pool.1.host = middleware.example.net
+# ... etc., similar to activemq settings
+
+# Security plugin settings (required):
+# -----------------------------------
+
+securityprovider = ssl
+
+# SSL plugin settings:
+plugin.ssl_client_cert_dir = /etc/mcollective.d/clients
+plugin.ssl_server_private = /etc/mcollective.d/server_private.pem
+plugin.ssl_server_public = /etc/mcollective.d/server_public.pem
+
+# PSK plugin settings:
+plugin.psk = j9q8kx7fnuied9e
+
+# Facts, identity, and classes (recommended):
+# ------------------------------------------
+
+factsource = yaml
+plugin.yaml = /etc/mcollective/facts.yaml
+fact_cache_time = 300
+
+identity = web01.example.com
+
+classesfile = /var/lib/puppet/state/classes.txt
+
+# Registration (recommended):
+# -----------------------
+
+registerinterval = 600
+registration_splay = true
+registration = agentlist
+registration_collective = mcollective
+
+# Subcollectives (optional):
+# -------------------------
+
+collectives = mcollective,uk_collective
+main_collective = mcollective
+
+# Auditing (optional):
+# -------------------
+
+rpcaudit = 1
+rpcauditprovider = logfile
+plugin.rpcaudit.logfile = /var/log/mcollective-audit.log
+
+# Authorization (optional):
+# ------------------------
+
+rpcauthorization = 1
+rpcauthprovider = action_policy
+
+# Logging:
+# -------
+
+logger_type = file
+loglevel = info
+logfile = /var/log/mcollective.log
+keeplogs = 5
+max_log_size = 2097152
+logfacility = user
+
+# Platform defaults:
+# -----------------
+
+daemonize = 1
+activate_agents = true
+soft_shutdown = false
+soft_shutdown_timeout = 5
+libdir = /usr/libexec/mcollective
+ssl_cipher = aes-256-cbc

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -2,15 +2,32 @@ require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
 
 unless ENV['BEAKER_provision'] == 'no'
+  # Work-around for BKR-262
+  @logger = logger
+
   hosts.each do |host|
     # Install Puppet
-    if host.is_pe?
+    if ENV['SHA']
+      install_puppetlabs_release_repo(host)
+      install_puppetlabs_dev_repo(host, 'puppet', ENV['SHA'])
+
+      #install_packages_from_local_dev_repo(host, 'puppet')
+      if host['platform'] =~ /debian|ubuntu|cumulus/
+        on host, 'apt-get install -y puppet'
+      elsif host['platform'] =~ /fedora|el|centos/
+        on host, 'yum install -y puppet'
+      else
+        raise "No repository installation step for #{host['platform']} yet..."
+      end
+    elsif host.is_pe?
       install_pe
     else
       install_puppet
     end
   end
 end
+
+configure_puppet(:main => {:stringify_facts => false, :parser => 'future'})
 
 RSpec.configure do |c|
   # Project root
@@ -25,6 +42,7 @@ RSpec.configure do |c|
     puppet_module_install(:source => proj_root, :module_name => 'agent_upgrade')
     hosts.each do |host|
       on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'puppetlabs-inifile'), { :acceptable_exit_codes => [0,1] }
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -5,19 +5,25 @@ unless ENV['BEAKER_provision'] == 'no'
   # Work-around for BKR-262
   @logger = logger
 
+  # Setup repositories if using a specific SHA
   hosts.each do |host|
-    # Install Puppet
     if ENV['SHA']
       install_puppetlabs_release_repo(host)
       install_puppetlabs_dev_repo(host, 'puppet', ENV['SHA'])
+    end
+  end
+end
 
-      #install_packages_from_local_dev_repo(host, 'puppet')
+def setup_puppet
+  hosts.each do |host|
+    # Install Puppet
+    if ENV['SHA']
       if host['platform'] =~ /debian|ubuntu|cumulus/
         on host, 'apt-get install -y puppet'
       elsif host['platform'] =~ /fedora|el|centos/
         on host, 'yum install -y puppet'
       else
-        raise "No repository installation step for #{host['platform']} yet..."
+        raise "No package installation step for #{host['platform']} yet..."
       end
     elsif host.is_pe?
       install_pe
@@ -25,24 +31,31 @@ unless ENV['BEAKER_provision'] == 'no'
       install_puppet
     end
   end
-end
 
-configure_puppet(:main => {:stringify_facts => false, :parser => 'future'})
+  configure_puppet(:main => {:stringify_facts => false, :parser => 'future'})
 
-RSpec.configure do |c|
   # Project root
   proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 
+  # Install module and dependencies
+  puppet_module_install(:source => proj_root, :module_name => 'agent_upgrade')
+  on hosts, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+  on hosts, puppet('module', 'install', 'puppetlabs-inifile'), { :acceptable_exit_codes => [0,1] }
+end
+
+def teardown_puppet
+  # Note pc1_repo is specific to the module's manifests. This is knowledge we need to clean
+  # the machine after each run.
+  pp = <<-EOS
+package { 'puppet-agent': ensure => absent }
+package { 'puppet': ensure => absent }
+file { ['/etc/puppet', '/etc/puppetlabs', '/etc/mcollective']: ensure => absent, force => true, backup => false }
+yumrepo { 'pc1_repo': ensure => absent }
+  EOS
+  on hosts, "/opt/puppetlabs/bin/puppet apply -e \"#{pp}\""
+end
+
+RSpec.configure do |c|
   # Readable test descriptions
   c.formatter = :documentation
-
-  # Configure all nodes in nodeset
-  c.before :suite do
-    # Install module and dependencies
-    puppet_module_install(:source => proj_root, :module_name => 'agent_upgrade')
-    hosts.each do |host|
-      on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
-      on host, puppet('module', 'install', 'puppetlabs-inifile'), { :acceptable_exit_codes => [0,1] }
-    end
-  end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,44 +1,111 @@
 require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
 
+def stop_firewall_on(host)
+  case host['platform']
+  when /debian/
+    on host, 'iptables -F'
+  when /fedora|el-7/
+    on host, puppet('resource', 'service', 'firewalld', 'ensure=stopped')
+  when /el|centos/
+    on host, puppet('resource', 'service', 'iptables', 'ensure=stopped')
+  when /ubuntu/
+    on host, puppet('resource', 'service', 'ufw', 'ensure=stopped')
+  else
+    logger.notify("Not sure how to clear firewall on #{host['platform']}")
+  end
+end
+
+# Project root
+PROJ_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
 unless ENV['BEAKER_provision'] == 'no'
   # Work-around for BKR-262
   @logger = logger
 
   # Setup repositories if using a specific SHA
-  hosts.each do |host|
-    if ENV['SHA']
+  if ENV['SHA']
+    hosts.each do |host|
       install_puppetlabs_release_repo(host)
       install_puppetlabs_dev_repo(host, 'puppet', ENV['SHA'])
+    end
+
+    if master
+      install_package master, 'puppet-server'
+      master['use-service'] = true
     end
   end
 end
 
-def setup_puppet
-  hosts.each do |host|
+def parser_opts
+  # Configuration only needed on 3.x master
+  {:main => {:stringify_facts => false, :parser => 'future'}}
+end
+
+def setup_puppet(agent_run = false)
+
+  agents.each do |agent|
     # Install Puppet
     if ENV['SHA']
-      if host['platform'] =~ /debian|ubuntu|cumulus/
-        on host, 'apt-get install -y puppet'
-      elsif host['platform'] =~ /fedora|el|centos/
-        on host, 'yum install -y puppet'
-      else
-        raise "No package installation step for #{host['platform']} yet..."
-      end
-    elsif host.is_pe?
+      install_package agent, 'puppet'
+    elsif agent.is_pe?
       install_pe
     else
       install_puppet
     end
+
+    configure_puppet_on(agent, parser_opts)
   end
 
-  configure_puppet(:main => {:stringify_facts => false, :parser => 'future'})
+  if master and agent_run
+    # Initialize SSL
+    hostname = on(master, 'facter hostname').stdout.strip
+    fqdn = on(master, 'facter fqdn').stdout.strip
 
-  # Project root
-  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+    if master.use_service_scripts?
+      step "Ensure puppet is stopped"
+      # Passenger, in particular, must be shutdown for the cert setup steps to work,
+      # but any running puppet master will interfere with webrick starting up and
+      # potentially ignore the puppet.conf changes.
+      on(master, puppet('resource', 'service', master['puppetservice'], "ensure=stopped"))
+    end
+
+    step "Clear SSL on all hosts"
+    hosts.each do |host|
+      stop_firewall_on host
+      ssldir = on(host, puppet('agent --configprint ssldir')).stdout.chomp
+      on(host, "rm -rf '#{ssldir}'")
+    end
+
+    step "Master: Start Puppet Master" do
+      master_opts = {
+        :main => {
+          :dns_alt_names => "puppet,#{hostname},#{fqdn}",
+        },
+        :__service_args__ => {
+          # apache2 service scripts can't restart if we've removed the ssl dir
+          :bypass_service_script => true,
+        },
+      }
+      with_puppet_running_on(master, master_opts, master.tmpdir('puppet')) do
+        step "Agents: Run agent --test first time to gen CSR"
+        on agents, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [1]
+
+        step "Master: sign all certs"
+        on master, puppet("cert --sign --all"), :acceptable_exit_codes => [0,24]
+
+        step "Agents: Run agent --test second time to obtain signed cert"
+        on agents, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [0,2]
+      end
+    end
+
+    if master.graceful_restarts?
+      on(master, puppet('resource', 'service', master['puppetservice'], "ensure=running"))
+    end
+  end
 
   # Install module and dependencies
-  puppet_module_install(:source => proj_root, :module_name => 'agent_upgrade')
+  puppet_module_install(:source => PROJ_ROOT, :module_name => 'agent_upgrade')
   on hosts, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
   on hosts, puppet('module', 'install', 'puppetlabs-inifile'), { :acceptable_exit_codes => [0,1] }
 end
@@ -52,7 +119,7 @@ package { 'puppet': ensure => absent }
 file { ['/etc/puppet', '/etc/puppetlabs', '/etc/mcollective']: ensure => absent, force => true, backup => false }
 yumrepo { 'pc1_repo': ensure => absent }
   EOS
-  on hosts, "/opt/puppetlabs/bin/puppet apply -e \"#{pp}\""
+  on agents, "/opt/puppetlabs/bin/puppet apply -e \"#{pp}\""
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
Update acceptance tests and nodesets to run basic testing.

Added running multiple test scenarios. Tests can be run with SHA=b94d3b4f2db8de95f151b98a2c6054daddbb0d4d bundle exec rspec spec/acceptance, which downloads a vagrant VM (uses default.yml) and runs it. Specifying a SHA should allow tests to be run in Jenkins as well.