### PR TITLE
(PUP-4559) Extend spec test to Puppet 3.7 and 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,16 @@
 language: ruby
 bundler_args: --without system_tests
 before_install: rm Gemfile.lock || true
-rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
 script: bundle exec rake test
-env:
-  - PUPPET_VERSION="3.8.0" FUTURE_PARSER=yes STRINGIFY_FACTS=no
+matrix:
+  include:
+    - rvm: 1.8.7
+      env: PUPPET_VERSION="3.7.5" FUTURE_PARSER=yes STRINGIFY_FACTS=no
+    - rvm: 1.8.7
+      env: PUPPET_VERSION="3.8.0" FUTURE_PARSER=yes STRINGIFY_FACTS=no
+    - rvm: 1.9.3
+      env: PUPPET_VERSION="3.8.0" FUTURE_PARSER=yes STRINGIFY_FACTS=no
+    - rvm: 2.0.0
+      env: PUPPET_VERSION="3.8.0" FUTURE_PARSER=yes STRINGIFY_FACTS=no
+    - rvm: 2.1.6
+      env: PUPPET_VERSION="4.0.0"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,18 +22,14 @@ class agent_upgrade (
   if versioncmp("$::clientversion", '3.8.0' ) < 0 {
     fail('upgrading requires Puppet 3.8')
   }
-  elsif versioncmp("$::clientversion", '4.0.0') >= 0 {
-    warning('Puppet 4+ already installed, nothing to do')
-  }
-  else {
-    class { '::agent_upgrade::prepare': } ->
-    class { '::agent_upgrade::install': } ->
-    class { '::agent_upgrade::config': } ~>
-    class { '::agent_upgrade::service': }
 
-    contain '::agent_upgrade::prepare'
-    contain '::agent_upgrade::install'
-    contain '::agent_upgrade::config'
-    contain '::agent_upgrade::service'
-  }
+  class { '::agent_upgrade::prepare': } ->
+  class { '::agent_upgrade::install': } ->
+  class { '::agent_upgrade::config': } ~>
+  class { '::agent_upgrade::service': }
+
+  contain '::agent_upgrade::prepare'
+  contain '::agent_upgrade::install'
+  contain '::agent_upgrade::config'
+  contain '::agent_upgrade::service'
 }

--- a/spec/classes/agent_upgrade_spec.rb
+++ b/spec/classes/agent_upgrade_spec.rb
@@ -14,26 +14,30 @@ describe 'agent_upgrade' do
               })
             end
 
-            [{}, {:service_names => []}].each do |params|
-              context "agent_upgrade class without any parameters" do
-                let(:params) { params }
+            if Puppet.version < "3.8.0"
+              it { expect { is_expected.to contain_package('agent_upgrade') }.to raise_error(Puppet::Error, /upgrading requires Puppet 3.8/) }
+            else
+              [{}, {:service_names => []}].each do |params|
+                context "agent_upgrade class without any parameters" do
+                  let(:params) { params }
 
-                it { is_expected.to compile.with_all_deps }
+                  it { is_expected.to compile.with_all_deps }
 
-                it { is_expected.to contain_class('agent_upgrade::params') }
-                it { is_expected.to contain_class('agent_upgrade::prepare') }
-                it { is_expected.to contain_class('agent_upgrade::install').that_comes_before('agent_upgrade::config') }
-                it { is_expected.to contain_class('agent_upgrade::config') }
-                it { is_expected.to contain_class('agent_upgrade::service').that_subscribes_to('agent_upgrade::config') }
+                  it { is_expected.to contain_class('agent_upgrade::params') }
+                  it { is_expected.to contain_class('agent_upgrade::prepare') }
+                  it { is_expected.to contain_class('agent_upgrade::install').that_comes_before('agent_upgrade::config') }
+                  it { is_expected.to contain_class('agent_upgrade::config') }
+                  it { is_expected.to contain_class('agent_upgrade::service').that_subscribes_to('agent_upgrade::config') }
 
-                if params[:service_names].nil?
-                  it { is_expected.to contain_service('puppet') }
-                  it { is_expected.to contain_service('mcollective') }
-                else
-                  it { is_expected.to_not contain_service('puppet') }
-                  it { is_expected.to_not contain_service('mcollective') }
+                  if params[:service_names].nil?
+                    it { is_expected.to contain_service('puppet') }
+                    it { is_expected.to contain_service('mcollective') }
+                  else
+                    it { is_expected.to_not contain_service('puppet') }
+                    it { is_expected.to_not contain_service('mcollective') }
+                  end
+                  it { is_expected.to contain_package('puppet-agent').with_ensure('present') }
                 end
-                it { is_expected.to contain_package('puppet-agent').with_ensure('present') }
               end
             end
           end


### PR DESCRIPTION
Extend spec testing to cover error case when using Puppet prior to 3.8,
and make no changes for Puppet 4.0+.