### PR TITLE
(PUP-4567) Add future parser in Rakefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ script: bundle exec rake test
 matrix:
   include:
     - rvm: 1.8.7
-      env: PUPPET_VERSION="3.7.5" FUTURE_PARSER=yes STRINGIFY_FACTS=no
+      env: PUPPET_VERSION="3.7.5"
     - rvm: 1.8.7
-      env: PUPPET_VERSION="3.8.0" FUTURE_PARSER=yes STRINGIFY_FACTS=no
+      env: PUPPET_VERSION="3.8.0"
     - rvm: 1.9.3
-      env: PUPPET_VERSION="3.8.0" FUTURE_PARSER=yes STRINGIFY_FACTS=no
+      env: PUPPET_VERSION="3.8.0"
     - rvm: 2.0.0
-      env: PUPPET_VERSION="3.8.0" FUTURE_PARSER=yes STRINGIFY_FACTS=no
+      env: PUPPET_VERSION="3.8.0"
     - rvm: 2.1.6
       env: PUPPET_VERSION="4.0.0"

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,11 @@
-require 'puppetlabs_spec_helper/rake_tasks'
+# Enable future parser and disable stringify facts for specs
 require 'puppet/version'
+if Puppet.version.to_f < 4.0
+  ENV['FUTURE_PARSER'] = 'yes'
+  ENV['STRINGIFY_FACTS'] = 'no'
+end
+
+require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppet-syntax/tasks/puppet-syntax'


### PR DESCRIPTION
Add the future parser requirement to the Rakefile, so it doesn't have to
be specified on every specs run. This simplifies maintenance of the
Jenkins pipeline used to run specs.