### PR TITLE
(maint) Clear ssldir and use default

### DIFF
--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -40,7 +40,7 @@ class agent_upgrade::prepare {
      # Deprecated for global config
      'config_version', 'manifest', 'modulepath',
      # Settings that should be reset to defaults
-     'disable_warnings', 'vardir', 'rundir', 'libdir', 'confdir'].each |$setting| {
+     'disable_warnings', 'vardir', 'rundir', 'libdir', 'confdir', 'ssldir'].each |$setting| {
       ini_setting { "${section}/${setting}":
         ensure  => absent,
         section => $section,

--- a/spec/classes/agent_upgrade_prepare_spec.rb
+++ b/spec/classes/agent_upgrade_prepare_spec.rb
@@ -89,6 +89,7 @@ describe 'agent_upgrade::prepare' do
        'smtphelo',
        'smtpport',
        'smtpserver',
+       'ssldir',
        'stringify_facts',
        'tagmap',
        'templatedir',

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -39,7 +39,10 @@ end
 
 def parser_opts
   # Configuration only needed on 3.x master
-  {:main => {:stringify_facts => false, :parser => 'future'}}
+  {
+    :main => {:stringify_facts => false, :parser => 'future'},
+    :agent => {:ssldir => '$vardir/ssl'},
+  }
 end
 
 def setup_puppet(agent_run = false)


### PR DESCRIPTION
Prior behavior would move ssl files to the new default location in
Puppet-Agent, but wouldn't clear the ssldir setting. If ssldir was
previously set using a variable that's changed - such as vardir -
Puppet-Agent would look for SSL files in the wrong place.

Rather than trying to resolve where ssldir would point under
Puppet-Agent before installing Puppet-Agent, clear ssldir so we use the
default.