### PR TITLE
(maint) Warn when using module in Puppet 4+

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,18 +18,21 @@ class agent_upgrade (
   $service_names = $::agent_upgrade::params::service_names,
 ) inherits ::agent_upgrade::params {
 
-  # check puppet version: if < 3.8, fail; elif >= 4.0, warn and stop; else proceed
-  if versioncmp("$::clientversion", '3.8.0' ) < 0 {
+  if versioncmp("$::clientversion", '3.8.0') < 0 {
     fail('upgrading requires Puppet 3.8')
   }
+  elsif versioncmp("$::clientversion", '4.0.0') >= 0 {
+    info('agent_upgrade performs no actions on Puppet 4+')
+  }
+  else {
+    class { '::agent_upgrade::prepare': } ->
+    class { '::agent_upgrade::install': } ->
+    class { '::agent_upgrade::config': } ~>
+    class { '::agent_upgrade::service': }
 
-  class { '::agent_upgrade::prepare': } ->
-  class { '::agent_upgrade::install': } ->
-  class { '::agent_upgrade::config': } ~>
-  class { '::agent_upgrade::service': }
-
-  contain '::agent_upgrade::prepare'
-  contain '::agent_upgrade::install'
-  contain '::agent_upgrade::config'
-  contain '::agent_upgrade::service'
+    contain '::agent_upgrade::prepare'
+    contain '::agent_upgrade::install'
+    contain '::agent_upgrade::config'
+    contain '::agent_upgrade::service'
+  }
 }

--- a/spec/classes/agent_upgrade_spec.rb
+++ b/spec/classes/agent_upgrade_spec.rb
@@ -25,19 +25,25 @@ describe 'agent_upgrade' do
 
                   it { is_expected.to contain_class('agent_upgrade') }
                   it { is_expected.to contain_class('agent_upgrade::params') }
-                  it { is_expected.to contain_class('agent_upgrade::prepare') }
-                  it { is_expected.to contain_class('agent_upgrade::install').that_comes_before('agent_upgrade::config') }
-                  it { is_expected.to contain_class('agent_upgrade::config') }
-                  it { is_expected.to contain_class('agent_upgrade::service').that_subscribes_to('agent_upgrade::config') }
+                  if Puppet.version < "4.0.0"
+                    it { is_expected.to contain_class('agent_upgrade::prepare') }
+                    it { is_expected.to contain_class('agent_upgrade::install').that_comes_before('agent_upgrade::config') }
+                    it { is_expected.to contain_class('agent_upgrade::config') }
+                    it { is_expected.to contain_class('agent_upgrade::service').that_subscribes_to('agent_upgrade::config') }
 
-                  if params[:service_names].nil?
-                    it { is_expected.to contain_service('puppet') }
-                    it { is_expected.to contain_service('mcollective') }
+                    if params[:service_names].nil?
+                      it { is_expected.to contain_service('puppet') }
+                      it { is_expected.to contain_service('mcollective') }
+                    else
+                      it { is_expected.to_not contain_service('puppet') }
+                      it { is_expected.to_not contain_service('mcollective') }
+                    end
+                    it { is_expected.to contain_package('puppet-agent').with_ensure('present') }
                   else
                     it { is_expected.to_not contain_service('puppet') }
                     it { is_expected.to_not contain_service('mcollective') }
+                    it { is_expected.to_not contain_package('puppet-agent') }
                   end
-                  it { is_expected.to contain_package('puppet-agent').with_ensure('present') }
                 end
               end
             end


### PR DESCRIPTION
In Puppet 4+, this module will continue to manage files related to the
upgrade. The main impact of this is reseting Puppet and Marionette
Collective configuration to defaults, which would be undesirable if
other changes are made.

Add a warning when running under Puppet 4+, reminding admins to remove
the module.