### PR TITLE
(PUP-4567) Fixes for acceptance and Beaker 2.12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,6 @@ group :test do
 end
 
 group :system_tests do
-  gem "beaker"
+  gem "beaker", '~> 2.11.0'
   gem "beaker-rspec"
 end

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper_acceptance'
 describe 'agent_upgrade class' do
 
   context 'default parameters' do
-    before(:all) { setup_puppet }
-    after (:all) { teardown_puppet }
+    before(:all) { setup_puppet_on default }
+    after (:all) { teardown_puppet_on default }
 
     it 'should work idempotently with no errors' do
       pp = <<-EOS
@@ -33,8 +33,8 @@ describe 'agent_upgrade class' do
   end
 
   context 'no services enabled on install' do
-    before(:all) { setup_puppet }
-    after (:all) { teardown_puppet }
+    before(:all) { setup_puppet_on default }
+    after (:all) { teardown_puppet_on default }
 
     it 'should work idempotently with no errors' do
       pp = <<-EOS
@@ -63,8 +63,8 @@ describe 'agent_upgrade class' do
   end
 
   context 'with mcollective configured' do
-    before(:all) { setup_puppet }
-    after (:all) { teardown_puppet }
+    before(:all) { setup_puppet_on default }
+    after (:all) { teardown_puppet_on default }
 
     it 'should work idempotently with no errors' do
       pp = <<-EOS
@@ -102,19 +102,19 @@ describe 'agent_upgrade class' do
   if master
     context 'agent run' do
       before(:all) {
-        setup_puppet true
+        setup_puppet_on default, true
         pp = "file { '#{master.puppet['confdir']}/manifests/site.pp': ensure => file, content => 'class { \"agent_upgrade\": }' }"
         apply_manifest_on(master, pp, :catch_failures => true)
       }
       after (:all) {
-        teardown_puppet
+        teardown_puppet_on default
         pp = "file { '#{master.puppet['confdir']}/manifests/site.pp': ensure => absent }"
         apply_manifest_on(master, pp, :catch_failures => true)
       }
 
       it 'should work idempotently with no errors' do
         with_puppet_running_on(master, parser_opts, master.tmpdir('puppet')) do
-          on agents, puppet("agent --test --server #{master}"), { :acceptable_exit_codes => [0,2] }
+          on default, puppet("agent --test --server #{master}"), { :acceptable_exit_codes => [0,2] }
         end
       end
 

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -2,6 +2,7 @@ HOSTS:
   centos-7-x64-master:
     roles:
       - master
+      - agent
     platform: el-7-x86_64
     box: puppetlabs/centos-7.0-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm


### PR DESCRIPTION
Without this change, acceptance fails because `step` expects to be in
the context of a test. They also fail specifically in CI because the
master also includes the agent role.

* Pin to a working version of Beaker; BKR-283 tracks fixing it.
* Use default instead of agents for the machine being tested.
* Also only sync modules when needed.