### PR TITLE
(maint) Use Puppet 3.8 gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ script: bundle exec rake test
 matrix:
   include:
     - rvm: 1.8.7
-      env: PUPPET_VERSION="3.7.5"
+      env: PUPPET_VERSION="~> 3.7.5"
     - rvm: 1.8.7
-      env: PUPPET_VERSION="3.8.0"
+      env: PUPPET_VERSION="~> 3.8.1"
     - rvm: 1.9.3
-      env: PUPPET_VERSION="3.8.0"
+      env: PUPPET_VERSION="~> 3.8.1"
     - rvm: 2.0.0
-      env: PUPPET_VERSION="3.8.0"
+      env: PUPPET_VERSION="~> 3.8.1"
     - rvm: 2.1.6
-      env: PUPPET_VERSION="4.0.0"
+      env: PUPPET_VERSION="~> 4.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 group :test do
   gem "rake"
-  gem "puppet", :git => 'https://github.com/puppetlabs/puppet.git', :tag => ENV['PUPPET_VERSION'] || '3.8.0'
+  gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.8.1'
   gem "rspec", '< 3.2.0'
   gem "rspec-puppet"
   gem "puppetlabs_spec_helper"


### PR DESCRIPTION
Puppet 3.8 gems were released as Puppet 3.8.1. Use those for testing,
rather than git.